### PR TITLE
argv -> sys.argv

### DIFF
--- a/resources/img4.py
+++ b/resources/img4.py
@@ -160,9 +160,9 @@ def img4stuff(deviceModel, iOSVersion, useCustomLogo, bootlogoPath):
             'iPod7,1': '12.3.1',
             'iPad7,5': '12.3.1',
             'iPad7,6': '12.3.1',
-            'iPhone6,2': argv[3],  # Since these have all keys up, we can just use whatever the downgraded version is =)
-            'iPhone6,1': argv[3],
-            'iPhone7,2': argv[3],
+            'iPhone6,2': sys.argv[3],  # Since these have all keys up, we can just use whatever the downgraded version is =)
+            'iPhone6,1': sys.argv[3],
+            'iPhone7,2': sys.argv[3],
             'iPhone7,1': '11.4.1'  # Test for 6+ support, may not work
         }
     screenSize = {


### PR DESCRIPTION
Hi,
this PR fixes the error below with `argv`. I renamed it `sys.argv`.
```
(env) ➜  PyBoot git:(master) ✗ ./pyboot.py -i iPhone7,2 11.3
PyBoot - A tool for tether booting Checkm8 vulnerable iOS devices by Matty, @mosk_i

Current version is: Beta 0.2
Make sure your device is connected in DFU mode
Traceback (most recent call last):
  File "./pyboot.py", line 140, in <module>
    main()
  File "./pyboot.py", line 120, in main
    img4.img4stuff(argv[2], argv[3], useCustomLogo, logopath)
  File "/Users/matteyeux/Documents/PyBoot/resources/img4.py", line 163, in img4stuff
    'iPhone6,2': argv[3],  # Since these have all keys up, we can just use whatever the downgraded version is =)
NameError: name 'argv' is not defined
```